### PR TITLE
Renamed "Team Foundation Server" to "Azure DevOps Server"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 [![Build Status](https://dev.azure.com/ms/azure-devops-dotnet-samples/_apis/build/status/Microsoft.azure-devops-dotnet-samples?branchName=master)](https://dev.azure.com/ms/azure-devops-dotnet-samples/_build/latest?definitionId=82&branchName=master)
 
-This repository contains C# samples that show how to integrate with Azure DevOps and Team Foundation Server using our [public client libraries](https://www.nuget.org/profiles/nugetvss), service hooks, and more.
+This repository contains C# samples that show how to integrate with  Azure DevOps Services and Azure using our [public client libraries](https://www.nuget.org/profiles/nugetvss), service hooks, and more.
 
 ## Explore the samples
 
-Take a minute to explore the repo. It contains short snippets as well as longer examples that demonstrate how to integrate with Azure DevOps and Team Foundation Server
+Take a minute to explore the repo. It contains short snippets as well as longer examples that demonstrate how to integrate with Azure DevOps Services and Azure DevOps Server
 
 * **Snippets**: short reusable code blocks demonstrating how to call specific APIs.
 * **Quickstarts**: self-contained programs demonstrating a specific scenario, typically by calling multiple APIs.
 
 ## About the official client libraries
 
-For .NET developers, the primary (and highly recommended) way to integrate with Azure DevOps and Team Foundation Server is via our public .NET client libraries available on Nuget. [Microsoft.TeamFoundationServer.Client](https://www.nuget.org/packages/Microsoft.TeamFoundationServer.Client) is the most popular Nuget package and contains clients for interacting with work item tracking, Git, version control, build, release management and other services.
+For .NET developers, the primary (and highly recommended) way to integrate with Azure DevOps Services and Azure DevOps Server is via our public .NET client libraries available on Nuget. [Microsoft.TeamFoundationServer.Client](https://www.nuget.org/packages/Microsoft.TeamFoundationServer.Client) is the most popular Nuget package and contains clients for interacting with work item tracking, Git, version control, build, release management and other services.
 
 See the [Azure DevOps client library documentation](https://docs.microsoft.com/en-us/azure/devops/integrate/concepts/dotnet-client-libraries?view=vsts) for more details.
 


### PR DESCRIPTION
The readme file still mentions "Team Foundation Server", which is now called "Azure DevOps Server".

@**maintainers**: Should we maybe mention at least once that it was formerly known as Team Foundation Server (aka TFS)?

Thanks,
--Neno