### PR TITLE
Service connection samples

### DIFF
--- a/ClientLibrary/Samples/ClientSamples.csproj
+++ b/ClientLibrary/Samples/ClientSamples.csproj
@@ -117,6 +117,9 @@
     <Reference Include="Microsoft.VisualStudio.Services.ReleaseManagement.WebApi, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.VisualStudio.Services.Release.Client.16.150.0-preview\lib\net45\Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi.16.150.0-preview\lib\net45\Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Services.ServiceHooks.WebApi, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.VisualStudio.Services.ServiceHooks.WebApi.16.150.0-preview\lib\net45\Microsoft.VisualStudio.Services.ServiceHooks.WebApi.dll</HintPath>
     </Reference>
@@ -184,6 +187,7 @@
     <Compile Include="ProjectsAndTeams\*.cs" />
     <Compile Include="Release\*.cs" />
     <Compile Include="Security\*.cs" />
+    <Compile Include="Serviceendpoint\EndpointsSample.cs" />
     <Compile Include="TaskGroups\*.cs" />
     <Compile Include="Test\*.cs" />
     <Compile Include="Tfvc\*.cs" />

--- a/ClientLibrary/Samples/Serviceendpoint/EndpointsSample.cs
+++ b/ClientLibrary/Samples/Serviceendpoint/EndpointsSample.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.VisualStudio.Services.FormInput;
+using Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
+
+namespace Microsoft.Azure.DevOps.ClientSamples.Serviceendpoint
+{
+    /// <summary>
+    /// 
+    /// Samples for interacting with Azure DevOps service endpoints (also known as service connections)
+    ///
+    /// Package: https://www.nuget.org/packages/Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi
+    /// 
+    /// </summary>
+    [ClientSample(ServiceEndpointResourceIds.AreaName, ServiceEndpointResourceIds.EndpointResource.Name)]
+    public class EndpointsSample : ClientSample
+    {
+        [ClientSampleMethod]
+        public IEnumerable<ServiceEndpointType> ListEndpointTypes()
+        {
+            // Get a service endpoint client instance
+            VssConnection connection = Context.Connection;
+            ServiceEndpointHttpClient endpointClient = connection.GetClient<ServiceEndpointHttpClient>();
+
+            // Get a list of all available service endpoint types
+            List<ServiceEndpointType> types = endpointClient.GetServiceEndpointTypesAsync().Result;
+
+            // Show details about each type in the console
+            foreach(ServiceEndpointType t in types)
+            {
+                Console.WriteLine(t.Name);
+
+                Console.WriteLine("Inputs:");
+                foreach (InputDescriptor input in t.InputDescriptors)
+                {
+                    Console.WriteLine("- {0}", input.Id);
+                }
+
+                Console.WriteLine("Schemes:");
+                foreach (ServiceEndpointAuthenticationScheme scheme in t.AuthenticationSchemes)
+                {
+                    Console.WriteLine("- {0}", scheme.Scheme);
+                    Console.WriteLine("  Inputs:");
+                    foreach (InputDescriptor input in scheme.InputDescriptors)
+                    {
+                        Console.WriteLine("  - {0}", input.Id);
+                    }
+                }
+
+                Console.WriteLine("================================");
+            }
+
+            return types;
+        }
+
+        [ClientSampleMethod]
+        public ServiceEndpoint CreateGenericEndpoint()
+        {
+            TeamProjectReference project = ClientSampleHelpers.FindAnyProject(this.Context);
+
+            // Get a service endpoint client instance
+            VssConnection connection = Context.Connection;
+            ServiceEndpointHttpClient endpointClient = connection.GetClient<ServiceEndpointHttpClient>();
+           
+            // Create a generic service endpoint 
+            ServiceEndpoint endpoint = endpointClient.CreateServiceEndpointAsync(project.Id, new ServiceEndpoint()
+            {
+                Name = "MyServiceEndpoint",
+                Type = ServiceEndpointTypes.Generic,
+                Url = new Uri("https://myserver"),
+                Authorization = new EndpointAuthorization()
+                {
+                    Scheme = EndpointAuthorizationSchemes.UsernamePassword,
+                    Parameters = new Dictionary<string, string>()
+                    {
+                        { "username", "myusername" },
+                        { "password", "mysecretpassword" }
+                    }
+                }
+            }).Result;
+
+            Console.WriteLine("Created endpoint: {0} {1} in {2}", endpoint.Id, endpoint.Name, project.Name);
+
+            return endpoint;
+        }
+
+        [ClientSampleMethod]
+        public IEnumerable<ServiceEndpoint> ListEndpoints()
+        {
+            TeamProjectReference project = ClientSampleHelpers.FindAnyProject(this.Context);
+
+            // Get a service endpoint client instance
+            VssConnection connection = Context.Connection;
+            ServiceEndpointHttpClient endpointClient = connection.GetClient<ServiceEndpointHttpClient>();
+
+            // Get a list of all "generic" service endpoints in the specified project
+            List<ServiceEndpoint> endpoints = endpointClient.GetServiceEndpointsAsync(
+                project: project.Id,
+                type: ServiceEndpointTypes.Generic).Result;
+
+            // Show the endpoints
+            Console.WriteLine("Endpoints in project: {0}", project.Name);
+            foreach (ServiceEndpoint endpoint in endpoints)
+            {
+                Console.WriteLine("- {0} {1}", endpoint.Id.ToString().PadLeft(6), endpoint.Name);
+            }
+
+            return endpoints;           
+        }
+    }
+}
+

--- a/ClientLibrary/Samples/packages.config
+++ b/ClientLibrary/Samples/packages.config
@@ -19,6 +19,7 @@
   <package id="Microsoft.VisualStudio.Services.InteractiveClient" version="16.150.0-preview" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Services.Notifications.WebApi" version="16.150.0-preview" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Services.Release.Client" version="16.150.0-preview" targetFramework="net452" />
+  <package id="Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi" version="16.150.0-preview" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Services.ServiceHooks.WebApi" version="16.150.0-preview" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.6.0-preview4.19212.13" targetFramework="net452" />


### PR DESCRIPTION
Adds a few service connection (also known as service endpoint) samples. Resolves issue #132 

* [x] Follow organization guidelines
* [x] Use real types (avoids `var`)
* [x] Use `Context.Log` (avoids Console.WriteLine)
* [x] Sample should clean up resources they create
* [x] Avoid samples that arbitrarily destroy data