### PR TITLE
Fix the location of the WordList.txt resource when reading from assembly.

### DIFF
--- a/ClientLibrary/Samples/Git/GitSampleHelpers.cs
+++ b/ClientLibrary/Samples/Git/GitSampleHelpers.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.DevOps.ClientSamples.Git
         {
             List<string> words = new List<string>();
 
-            string wordListName = "Microsoft.TeamServices.Samples.Client.Git.WordList.txt";
+            string wordListName = "Microsoft.Azure.DevOps.ClientSamples.Git.WordList.txt";
             using (Stream inputStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(wordListName))
             using (StreamReader reader = new StreamReader(inputStream))
             {


### PR DESCRIPTION
I was unable to run the git example "PushesSample.cs".   It was getting an exception when attempting to load the resource file WordList.txt.  I corrected the location so it would run without an exception. 