### PR TITLE
typo error, Properaties to Properties

### DIFF
--- a/ClientLibrary/Samples/ProjectsAndTeams/ProjectsSample.cs
+++ b/ClientLibrary/Samples/ProjectsAndTeams/ProjectsSample.cs
@@ -134,9 +134,9 @@ namespace Microsoft.Azure.DevOps.ClientSamples.ProjectsAndTeams
             ProcessHttpClient processClient = Context.Connection.GetClient<ProcessHttpClient>();
             Guid processId = processClient.GetProcessesAsync().Result.Find(process => { return process.Name.Equals(processName, StringComparison.InvariantCultureIgnoreCase); }).Id;
 
-            Dictionary<string, string> processProperaties = new Dictionary<string, string>();
+            Dictionary<string, string> processProperties = new Dictionary<string, string>();
 
-            processProperaties[TeamProjectCapabilitiesConstants.ProcessTemplateCapabilityTemplateTypeIdAttributeName] =
+            processProperties[TeamProjectCapabilitiesConstants.ProcessTemplateCapabilityTemplateTypeIdAttributeName] =
                 processId.ToString();
 
             // Construct capabilities dictionary
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.DevOps.ClientSamples.ProjectsAndTeams
             capabilities[TeamProjectCapabilitiesConstants.VersionControlCapabilityName] = 
                 versionControlProperties;
             capabilities[TeamProjectCapabilitiesConstants.ProcessTemplateCapabilityName] = 
-                processProperaties;
+                processProperties;
 
             // Construct object containing properties needed for creating the project
             TeamProject projectCreateParameters = new TeamProject()


### PR DESCRIPTION
Changing typo error processProperaties ==> processProperties

### Sample snippet contributions

For client library sample snippets, review and follow the [snippet contribution guidance](https://github.com/Microsoft/vsts-dotnet-samples/blob/master/ClientLibrary/Snippets/contribute.md)

* [ ] Follow organization guidelines
* [ ] Use real types (avoids `var`)
* [ ] Use `Context.Log` (avoids Console.WriteLine)
* [ ] Sample should clean up resources they create
* [ ] Avoid samples that arbitrarily destroy data